### PR TITLE
Caleb Spraul - sprint challenge done

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 *.pyc
 .vscode/
+Pipfile*

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ buffer.get()   # should return ['d', 'e', 'f']
 
 Navigate into the `names` directory. Here you will find two text files containing 10,000 names each, along with a program `names.py` that compares the two files and prints out duplicate name entries. Try running the code with `python3 names.py`. Be patient because it might take a while: approximately six seconds on my laptop. What is the runtime complexity of this code?
 
+***Runtime complexity of the original code: O(n^2)***
+
 Six seconds is an eternity so you've been tasked with speeding up the code. Can you get the runtime to under a second? Under one hundredth of a second?
 
 *You may not use the built in Python list, set, or dictionary in your solution for this problem.  However, you can and should use the provided `duplicates` list to return your solution.*

--- a/names/binary_search_tree.py
+++ b/names/binary_search_tree.py
@@ -1,0 +1,118 @@
+"""
+Binary search trees are a data structure that enforce an ordering over 
+the data they store. That ordering in turn makes it a lot more efficient 
+at searching for a particular piece of data in the tree. 
+
+This part of the project comprises two days:
+1. Implement the methods `insert`, `contains`, `get_max`, and `for_each`
+   on the BSTNode class.
+2. Implement the `in_order_print`, `bft_print`, and `dft_print` methods
+   on the BSTNode class.
+"""
+
+from queue import LifoQueue, Queue
+
+
+class BSTNode:
+    def __init__(self, value):
+        self.value = value
+        self.left = None
+        self.right = None
+
+    # Insert the given value into the tree
+    def insert(self, value):
+        if value < self.value:
+            if self.left is not None:
+                self.left.insert(value)
+            else:
+                self.left = BSTNode(value)
+        elif value >= self.value:
+            if self.right is not None:
+                self.right.insert(value)
+            else:
+                self.right = BSTNode(value)
+
+    # Return True if the tree contains the value
+    # False if it does not
+    def contains(self, target):
+        if target < self.value:
+            if self.left is not None:
+                return self.left.contains(target)
+        elif target > self.value:
+            if self.right is not None:
+                return self.right.contains(target)
+        elif target == self.value:
+            return True
+        else:
+            return False
+
+    # Return the maximum value found in the tree
+    def get_max(self):
+        if self.right is not None:
+            return self.right.get_max()
+        else:
+            return self.value
+
+    # Call the function `fn` on the value of each node
+    def for_each(self, fn):
+        if self.left is not None:
+            self.left.for_each(fn)
+        if self.right is not None:
+            self.right.for_each(fn)
+        fn(self.value)
+
+    # Part 2 -----------------------
+
+    # Print all the values in order from low to high
+    # Hint:  Use a recursive, depth first traversal
+    def in_order_print(self, node):
+        if node.left is not None:
+            node.in_order_print(node.left)
+        print(node.value)
+        if node.right is not None:
+            node.in_order_print(node.right)
+    
+    # Print the value of every node, starting with the given node,
+    # in an iterative breadth first traversal
+    def bft_print(self, node):
+        queue = Queue()
+        queue.put(node)
+        while not queue.empty():
+            current_node = queue.get()
+            print(current_node.value)
+            if current_node.left is not None:
+                queue.put(current_node.left)
+            if current_node.right is not None:
+                queue.put(current_node.right)
+
+    # Print the value of every node, starting with the given node,
+    # in an iterative depth first traversal
+    def dft_print(self, node):
+        stack = LifoQueue()
+        stack.put(node)
+        while not stack.empty():
+            current_node = stack.get()
+            print(current_node.value)
+            if current_node.right is not None:
+                stack.put(current_node.right)
+            if current_node.left is not None:
+                stack.put(current_node.left)
+
+    # Stretch Goals -------------------------
+    # Note: Research may be required
+
+    # Print Pre-order recursive DFT
+    def pre_order_dft(self, node):
+        print(node.value)
+        if node.left is not None:
+            node.pre_order_dft(node.left)
+        if node.right is not None:
+            node.pre_order_dft(node.right)
+
+    # Print Post-order recursive DFT
+    def post_order_dft(self, node):
+        if node.left is not None:
+            node.post_order_dft(node.left)
+        if node.right is not None:
+            node.post_order_dft(node.right)
+        print(node.value)

--- a/names/names.py
+++ b/names/names.py
@@ -39,7 +39,7 @@ print (f"runtime: {end_time - start_time} seconds")
 # What's the best time you can accomplish?  Thare are no restrictions on techniques or data
 # structures, but you may not import any additional libraries that you did not write yourself.
 
-print('\n\n------------------ Stretch -----------------\n\n')
+print('\n\n------------------ Stretch from names.py -----------------')
 
 start_time = time.time()
 
@@ -58,3 +58,26 @@ print (f"{len(duplicates)} duplicates:\n\n{', '.join(duplicates)}\n\n")
 print (f"runtime: {end_time - start_time} seconds")
 
 # runtime: 0.006196260452270508 seconds
+
+
+print('\n\n------------------ Stretch from README.md -----------------')
+
+start_time = time.time()
+
+f = open(full_path('names_1.txt'), 'r')
+names_1 = f.read().split("\n")  # List containing 10000 names
+f.close()
+
+duplicates = []
+
+f = open(full_path('names_2.txt'), 'r')
+for line in f:
+    if line[:-1] in names_1:
+        duplicates.append(line[:-1])
+f.close()
+
+end_time = time.time()
+print (f"{len(duplicates)} duplicates:\n\n{', '.join(duplicates)}\n\n")
+print (f"runtime: {end_time - start_time} seconds")
+
+# runtime: 2.237161159515381 seconds

--- a/names/names.py
+++ b/names/names.py
@@ -1,12 +1,18 @@
-import time
+import os, time
+
+
+def full_path(filename:str) -> str:
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    return os.path.join(current_dir, filename)
+
 
 start_time = time.time()
 
-f = open('names_1.txt', 'r')
+f = open(full_path('names_1.txt'), 'r')
 names_1 = f.read().split("\n")  # List containing 10000 names
 f.close()
 
-f = open('names_2.txt', 'r')
+f = open(full_path('names_2.txt'), 'r')
 names_2 = f.read().split("\n")  # List containing 10000 names
 f.close()
 

--- a/names/names.py
+++ b/names/names.py
@@ -32,8 +32,29 @@ print (f"{len(duplicates)} duplicates:\n\n{', '.join(duplicates)}\n\n")
 print (f"runtime: {end_time - start_time} seconds")
 
 # went from > 12 seconds to < 1 second
+# runtime: 0.1772751808166504 seconds
 
 # ---------- Stretch Goal -----------
 # Python has built-in tools that allow for a very efficient approach to this problem
 # What's the best time you can accomplish?  Thare are no restrictions on techniques or data
 # structures, but you may not import any additional libraries that you did not write yourself.
+
+print('\n\n------------------ Stretch -----------------\n\n')
+
+start_time = time.time()
+
+f = open(full_path('names_1.txt'), 'r')
+names_1 = set(f.read().split("\n"))  # List containing 10000 names
+f.close()
+
+f = open(full_path('names_2.txt'), 'r')
+names_2 = set(f.read().split("\n"))  # List containing 10000 names
+f.close()
+
+duplicates = list(names_1.intersection(names_2))
+
+end_time = time.time()
+print (f"{len(duplicates)} duplicates:\n\n{', '.join(duplicates)}\n\n")
+print (f"runtime: {end_time - start_time} seconds")
+
+# runtime: 0.006196260452270508 seconds

--- a/names/names.py
+++ b/names/names.py
@@ -1,5 +1,7 @@
 import os, time
 
+from binary_search_tree import BSTNode
+
 
 def full_path(filename:str) -> str:
     current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -16,17 +18,20 @@ f = open(full_path('names_2.txt'), 'r')
 names_2 = f.read().split("\n")  # List containing 10000 names
 f.close()
 
-duplicates = []  # Return the list of duplicates in this data structure
+# create first binary search tree node
+bst = BSTNode(names_1[0])
+# populate binary search tree with remaining names
+for name in names_1[1:]:
+    bst.insert(name)
 
-# Replace the nested for loops below with your improvements
-for name_1 in names_1:
-    for name_2 in names_2:
-        if name_1 == name_2:
-            duplicates.append(name_1)
+# find duplicates
+duplicates = [name for name in names_2 if bst.contains(name)]
 
 end_time = time.time()
 print (f"{len(duplicates)} duplicates:\n\n{', '.join(duplicates)}\n\n")
 print (f"runtime: {end_time - start_time} seconds")
+
+# went from > 12 seconds to < 1 second
 
 # ---------- Stretch Goal -----------
 # Python has built-in tools that allow for a very efficient approach to this problem

--- a/reverse/reverse.py
+++ b/reverse/reverse.py
@@ -39,4 +39,12 @@ class LinkedList:
         return False
 
     def reverse_list(self, node, prev):
-        pass
+        # change node to point to previous
+        # call again with next and current node
+        if node is not None:
+            self.reverse_list(node.next_node, node)
+            node.next_node = prev
+        # when reach end of list
+        # set list head to last known node
+        else:
+            self.head = prev

--- a/reverse/reverse.py
+++ b/reverse/reverse.py
@@ -39,8 +39,9 @@ class LinkedList:
         return False
 
     def reverse_list(self, node, prev):
-        # change node to point to previous
+        # if not at end of list
         # call again with next and current node
+        # change node to point to previous
         if node is not None:
             self.reverse_list(node.next_node, node)
             node.next_node = prev

--- a/ring_buffer/ring_buffer.py
+++ b/ring_buffer/ring_buffer.py
@@ -1,9 +1,58 @@
 class RingBuffer:
+    class RingNode:
+        def __init__(self):
+            self.value = None
+            self.next = None
+
     def __init__(self, capacity):
-        pass
+        self.capacity = capacity
+        
+        # create head node
+        # only reason to track head node is (IMO incorrect) requirements
+        # in the example and tests that the items returned from .get()
+        # start with the first 'slot' that was filled instead of starting
+        # with the oldest item in the buffer
+        self.first_node = RingBuffer.RingNode()
+        
+        # keep track of capacity while initializing buffer
+        capacity = capacity - 1
+
+        # node pointer
+        self.current_node = self.first_node
+
+        # create remaining ring
+        while capacity > 0:
+            self.current_node.next = RingBuffer.RingNode()
+            self.current_node = self.current_node.next
+            capacity = capacity - 1
+        
+        # chain ring back to head
+        self.current_node.next = self.first_node
+
+        # reset node pointer to head
+        # only need to do this because of requirements
+        # a real ring buffer wouldn't track a 'starting point'
+        # because it is circular
+        self.current_node = self.first_node
+
 
     def append(self, item):
-        pass
+        # set value
+        self.current_node.value = item
+        # move forward in chain
+        self.current_node = self.current_node.next
 
     def get(self):
-        pass
+        items = []
+
+        # start at head (due to spec / tests)
+        # actual ring node should start at oldest item
+        # which would be `self.current_node`
+        current_node = self.first_node
+        # walk chain, retrieve non-null values
+        for i in range(self.capacity):
+            if current_node.value is not None:
+                items.append(current_node.value)
+            current_node = current_node.next
+
+        return items


### PR DESCRIPTION
The specifications for a ring buffer in the example and in the tests do not make sense to me.

When a ring buffer's contents are retrieved, they should start with the oldest item and continue to the newest item.

As the spec stands, when the ring buffer is retrieved, it starts with whatever happens to be in the slot of the first item inserted, continues to the newest item, then continues with the oldest item up to the first slot.

Spec as stated:
- RingBuffer(10)
- .append(1...15)
- .get() = [11, 12, 13, 14, 15, 6, 7, 8, 9, 10]

Should be:
- RingBuffer(10)
- .append(1...15)
- .get() = [6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
